### PR TITLE
Update HateosWriteInterceptor to not include AtomLinks if relativePath

### DIFF
--- a/src/main/java/edu/psu/swe/commons/jaxrs/hateoas/interceptor/HateoasWriteInterceptor.java
+++ b/src/main/java/edu/psu/swe/commons/jaxrs/hateoas/interceptor/HateoasWriteInterceptor.java
@@ -147,9 +147,11 @@ public class HateoasWriteInterceptor implements WriterInterceptor {
       }
     }
 
-    atomLink.setHyperlink(uriInfo.getBaseUri() + path);
-
-    instance.getLinks().add(atomLink);
+    if (path != null && !path.trim().isEmpty()) { 
+      atomLink.setHyperlink(uriInfo.getBaseUri() + path);
+  
+      instance.getLinks().add(atomLink);
+    }
   }
 
 }


### PR DESCRIPTION
Stops inclusion of null or empty paths in Hateos 