### PR TITLE
Adds properties to allow for setting of headers.

### DIFF
--- a/src/main/java/edu/psu/swe/commons/jaxrs/ErrorMessage.java
+++ b/src/main/java/edu/psu/swe/commons/jaxrs/ErrorMessage.java
@@ -21,10 +21,13 @@ package edu.psu.swe.commons.jaxrs;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -39,36 +42,52 @@ import edu.psu.swe.commons.jaxrs.adapters.XmlStatusAdapter;
 @XmlAccessorType(XmlAccessType.NONE)
 public class ErrorMessage
 {
+
   @XmlElement(name="status")
   @XmlJavaTypeAdapter(XmlStatusAdapter.class)
   private Status status;
-  
+
   @XmlElementWrapper(name="errorMessageList")
   @XmlElement(name="errorMessage")
   List<String> errorMessages = new ArrayList<>();
-  
+
   @XmlElementWrapper(name="referenceList", nillable = true)
   @XmlElement(name = "link", nillable = true)
   List<String> externalLinks = null;
-  
+
+  Map<String, Object> headerMap = new HashMap<>();
+
   public ErrorMessage()
   {}
-  
+
   public ErrorMessage(Status status)
   {
     this.status = status;
   }
-   
+
   public void setStatus(Status status)
   {
     this.status = status;
   }
-  
+
   public Status getStatus()
   {
     return status;
   }
-  
+
+  public Map<String, Object> getHeaderMap() {
+    return headerMap;
+  }
+
+  public void setHeader(String header, Object value) {
+    this.headerMap.put(header, value);
+  }
+
+  public Object removeHeader(String header) {
+    return this.headerMap.remove(header);
+  }
+
+
   public void setErrorMessageList(List<String> messageList)
   {
     if (messageList == null)
@@ -80,52 +99,52 @@ public class ErrorMessage
       errorMessages = messageList;
     }
   }
-  
+
   public void addErrorMessage(String message)
   {
     errorMessages.add(message);
   }
-  
+
   public List<String> getErrorMessageList()
   {
     return Collections.unmodifiableList(errorMessages);
   }
-  
+
   public void setExternalLinkList(List<String> linkList)
   {
     externalLinks = linkList;
   }
-  
+
   public void addExtenalLink(URL link)
   {
     if (externalLinks == null)
     {
       externalLinks  = new ArrayList<>();
     }
-    
+
     externalLinks.add(link.toString());
   }
-  
+
   public List<String> getExternalLinkList()
   {
     return externalLinks;
   }
-  
+
   public Response toResponse()
   {
-    return Response.status(status).entity(this).build();
+    return buildResponse(status).build();
   }
-  
+
   public Response toResponse(String mediaType)
   {
-    return Response.status(status).entity(this).type(mediaType).build();
+    return buildResponse(status).type(mediaType).build();
   }  
-  
+
   public Response toResponse(MediaType mediaType)
   {
-    return Response.status(status).entity(this).type(mediaType).build();
+    return buildResponse(status).type(mediaType).build();
   }  
-  
+
   @Override
   public String toString()
   {
@@ -133,7 +152,7 @@ public class ErrorMessage
     sb.append("Status = ");
     sb.append(status.getStatusCode());
     sb.append("\n");
-    
+
     if (errorMessages != null)
     {
       sb.append("Error Messages");
@@ -144,7 +163,7 @@ public class ErrorMessage
         sb.append("\n");
       }
     }
-    
+
     if (externalLinks != null)
     {
       sb.append("External Links");
@@ -155,5 +174,19 @@ public class ErrorMessage
       }
     }
     return sb.toString();
+  }
+
+
+  private ResponseBuilder buildResponse(Status status){
+    ResponseBuilder builder = Response.status(status);
+
+    for(Map.Entry<String, Object> entry : headerMap.entrySet()) {
+      String key = entry.getKey();
+      Object value = entry.getValue();
+      builder.header(key, value);
+    }
+    builder.entity(this);
+
+    return builder;
   }
 }

--- a/src/test/java/edu/psu/swe/commons/jaxrs/ErrorMessageTest.java
+++ b/src/test/java/edu/psu/swe/commons/jaxrs/ErrorMessageTest.java
@@ -1,0 +1,81 @@
+package edu.psu.swe.commons.jaxrs;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ErrorMessageTest {
+
+  ErrorMessage em;
+
+  @Before 
+  public void init() {
+    em = new ErrorMessage();
+    em.setStatus(Status.INTERNAL_SERVER_ERROR);
+    em.setHeader(HttpHeaders.RETRY_AFTER, 900);
+    em.setHeader(HttpHeaders.ETAG, "ETag123456789");
+  }
+
+  @Test
+  public void add_headers_test() {
+
+    Assert.assertNotNull(em.getHeaderMap());
+    Assert.assertTrue("The header map does not contain any entries.", em.getHeaderMap().size() > 0);
+    Assert.assertTrue("The Retry-After header is missing.", em.getHeaderMap().containsKey(HttpHeaders.RETRY_AFTER));
+    Assert.assertTrue("The ETAG header is missing.", em.getHeaderMap().containsKey(HttpHeaders.ETAG));
+  }
+
+  @Test
+  public void remove_headers_test() {
+
+    Assert.assertNotNull(em.getHeaderMap());
+    Assert.assertTrue("The header map does not contain any entries.", em.getHeaderMap().size() > 0);
+
+    Assert.assertEquals("The Retry-After header is missing.", em.removeHeader(HttpHeaders.RETRY_AFTER), 900);
+    Assert.assertEquals("The Content-Type header is missing.", em.removeHeader(HttpHeaders.ETAG), "ETag123456789");
+    Assert.assertFalse(em.getHeaderMap().containsKey(HttpHeaders.RETRY_AFTER));
+    Assert.assertFalse(em.getHeaderMap().containsKey(HttpHeaders.ETAG));
+
+    Assert.assertTrue("The header map is expected to be empty but contains " + em.getHeaderMap().size() + " entries.", em.getHeaderMap().size() == 0);
+  }
+
+  @Test
+  public void build_response_test() {
+
+    Response response = em.toResponse();
+    MultivaluedMap<String, Object> headers = response.getHeaders();
+
+    Assert.assertEquals("Expected response status of " + Status.INTERNAL_SERVER_ERROR.getStatusCode() + " but received " + response.getStatus() + " instead.", response.getStatus(), Status.INTERNAL_SERVER_ERROR.getStatusCode());
+    Assert.assertTrue("The response object does not contain the expected Retry-After key.",headers.containsKey(HttpHeaders.RETRY_AFTER));
+    Assert.assertTrue("The response object does not contain the ETAG key.", headers.containsKey(HttpHeaders.ETAG));
+
+  }
+
+  @Test
+  public void build_response_media_type_test() {
+    Response response = em.toResponse("text/plain");
+    Map<String, List<Object>> headers = response.getHeaders();
+    Assert.assertTrue("The response object does not contain the Content-type key.", headers.containsKey(HttpHeaders.CONTENT_TYPE));
+
+  }
+
+  @Test
+  public void build_response_string_media_type_test() {
+    Response response = em.toResponse(MediaType.APPLICATION_JSON);
+    
+    Map<String, List<Object>> headers = response.getHeaders();
+    Assert.assertTrue("The response object does not contain the Content-type key.", headers.containsKey(HttpHeaders.CONTENT_TYPE));
+
+  }
+
+
+}


### PR DESCRIPTION
Do we want to restrict the Header properties in the error class to only allow certain header types to be set? Maybe validate that the header key being added is a valid type from javax.ws.rs.core.HttpHeaders?