### PR TITLE
Adding JsonSerializationUtil

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,21 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-jaxb-annotations</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jaxb-provider</artifactId>
       <version>${resteasy.version}</version>
@@ -161,7 +176,7 @@
       <artifactId>javaee-api</artifactId>
       <version>7.0</version>
     </dependency>
-    <dependency>
+    <!-- <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
       <version>${jackson.version}</version>
@@ -175,7 +190,7 @@
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
       <version>${jackson.version}</version>
-    </dependency>
+    </dependency> -->
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -176,21 +176,6 @@
       <artifactId>javaee-api</artifactId>
       <version>7.0</version>
     </dependency>
-    <!-- <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-annotations</artifactId>
-      <version>${jackson.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.module</groupId>
-      <artifactId>jackson-module-jaxb-annotations</artifactId>
-      <version>${jackson.version}</version>
-    </dependency> -->
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>

--- a/src/main/java/edu/psu/swe/commons/jaxrs/utilities/JsonSerializationUtil.java
+++ b/src/main/java/edu/psu/swe/commons/jaxrs/utilities/JsonSerializationUtil.java
@@ -1,0 +1,39 @@
+package edu.psu.swe.commons.jaxrs.utilities;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.psu.swe.commons.jaxrs.server.ObjectMapperContextResolver;
+
+public class JsonSerializationUtil {
+  
+private static final ObjectMapper mapper;
+  
+  static {
+    ObjectMapperContextResolver resolver = new ObjectMapperContextResolver();
+    mapper = resolver.getContext(null);
+  }
+  
+  public static String serialize(Object obj) throws IOException {
+    StringWriter writer = new StringWriter();
+    mapper.writeValue(writer, obj);
+    return writer.toString();
+  }
+  
+  public static <T> T deserialize(String json, T t) throws IOException {
+    @SuppressWarnings("unchecked")
+    T obj = (T) mapper.readValue(json, t.getClass());
+    return obj;
+  }
+  
+  public static <T> List<T> deserializeList(String json, Class<T> clazz) throws IOException {
+    JavaType type = mapper.getTypeFactory().constructCollectionType(List.class, clazz);
+    List<T> list = mapper.readValue(json, type);
+    return list;
+  }
+
+}

--- a/src/main/java/edu/psu/swe/commons/jaxrs/utilities/JsonSerializationUtil.java
+++ b/src/main/java/edu/psu/swe/commons/jaxrs/utilities/JsonSerializationUtil.java
@@ -1,4 +1,4 @@
-ckage edu.psu.swe.commons.jaxrs.utilities;
+package edu.psu.swe.commons.jaxrs.utilities;
 
 import java.io.IOException;
 import java.io.StringWriter;

--- a/src/main/java/edu/psu/swe/commons/jaxrs/utilities/JsonSerializationUtil.java
+++ b/src/main/java/edu/psu/swe/commons/jaxrs/utilities/JsonSerializationUtil.java
@@ -1,8 +1,9 @@
-package edu.psu.swe.commons.jaxrs.utilities;
+ckage edu.psu.swe.commons.jaxrs.utilities;
 
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.List;
+import java.util.Optional;
 
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -18,22 +19,35 @@ private static final ObjectMapper mapper;
     mapper = resolver.getContext(null);
   }
   
-  public static String serialize(Object obj) throws IOException {
+  public static Optional<String> serialize(Object obj) throws IOException {
+    if (obj == null) {
+      return Optional.empty();
+    }
     StringWriter writer = new StringWriter();
     mapper.writeValue(writer, obj);
-    return writer.toString();
+    return Optional.ofNullable(writer.toString());
   }
   
-  public static <T> T deserialize(String json, T t) throws IOException {
+  public static <T> Optional<T> deserialize(String json, Class<T> clazz) throws IOException {
+    if (json == null || json.trim().isEmpty()) {
+      return Optional.empty();
+    }
     @SuppressWarnings("unchecked")
-    T obj = (T) mapper.readValue(json, t.getClass());
-    return obj;
+    T obj = (T) mapper.readValue(json, clazz);
+    return Optional.of(obj);
   }
   
-  public static <T> List<T> deserializeList(String json, Class<T> clazz) throws IOException {
+  public static <T> Optional<List<T>> deserializeList(String json, Class<T> clazz) throws IOException {
+    if (json == null || json.trim().isEmpty()) {
+      return Optional.empty();
+    }
     JavaType type = mapper.getTypeFactory().constructCollectionType(List.class, clazz);
     List<T> list = mapper.readValue(json, type);
-    return list;
+    if (list.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.of(list);
   }
 
 }
+

--- a/src/test/java/edu/psu/swe/common/jaxrs/utilities/JsonSerializationUtilTest.java
+++ b/src/test/java/edu/psu/swe/common/jaxrs/utilities/JsonSerializationUtilTest.java
@@ -1,0 +1,106 @@
+package edu.psu.swe.common.jaxrs.utilities;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import javax.xml.bind.annotation.XmlElement;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import edu.psu.swe.commons.jaxrs.utilities.JsonSerializationUtil;
+import lombok.Data;
+
+public class JsonSerializationUtilTest {
+  
+  private static final String EMPTY = "";
+  private static final String EMPTY_LIST = "[]";
+  private static final String EXAMPLE_OBJECT_STR = "{\"str\":\"Hello World\",\"num\":5}";
+  private static final String EXAMPLE_LIST_STR = "[{\"str\":\"Hello World\",\"num\":5},{\"str\":\"Second Time\",\"num\":10}]";
+  private static final SerialObject exampleObject1;
+  private static final SerialObject exampleObject2;
+  private static final List<SerialObject> exampleList;
+  
+  static {
+    exampleObject1 = new SerialObject();
+    exampleObject1.setStr("Hello World");
+    exampleObject1.setNum(5);
+    
+    exampleObject2 = new SerialObject();
+    exampleObject2.setStr("Second Time");
+    exampleObject2.setNum(10);
+    
+    exampleList = new ArrayList<>();
+    exampleList.add(exampleObject1);
+    exampleList.add(exampleObject2);
+  }
+
+  
+  @Test
+  public void testSerializeObject() throws IOException {
+    //Test Serialize Object
+    Optional<String> optional = JsonSerializationUtil.serialize(exampleObject1);
+    Assert.assertTrue(optional.isPresent());
+    Assert.assertEquals(EXAMPLE_OBJECT_STR, optional.get());
+    
+    //Test Serialize List
+    optional = JsonSerializationUtil.serialize(exampleList);
+    Assert.assertTrue(optional.isPresent());
+    Assert.assertEquals(EXAMPLE_LIST_STR, optional.get());
+    
+    //Test Null String
+    optional = JsonSerializationUtil.serialize(null);
+    Assert.assertTrue(!optional.isPresent());
+  }
+  
+  @Test
+  public void testDeserializeObject() throws IOException {
+    Optional<SerialObject> optional = JsonSerializationUtil.deserialize(EXAMPLE_OBJECT_STR, SerialObject.class);
+    Assert.assertTrue(optional.isPresent());
+    Assert.assertEquals(exampleObject1, optional.get());
+    
+    //Test Null String
+    optional = JsonSerializationUtil.deserialize(null, SerialObject.class);
+    Assert.assertTrue(!optional.isPresent());
+    
+    //Test Empty String
+    optional = JsonSerializationUtil.deserialize(EMPTY, SerialObject.class);
+    Assert.assertTrue(!optional.isPresent());
+  }
+  
+  @Test
+  public void testDeserializeList() throws IOException {
+    Optional<List<SerialObject>> optional = JsonSerializationUtil.deserializeList(EXAMPLE_LIST_STR, SerialObject.class);
+    Assert.assertTrue(optional.isPresent());
+    Assert.assertEquals(exampleList, optional.get());
+    
+    //Test Empty List String
+    optional = JsonSerializationUtil.deserializeList(EMPTY_LIST, SerialObject.class);
+    Assert.assertTrue(!optional.isPresent());
+    
+    //Test Null String
+    optional = JsonSerializationUtil.deserializeList(null, SerialObject.class);
+    Assert.assertTrue(!optional.isPresent());
+    
+    //Test Empty String
+    optional = JsonSerializationUtil.deserializeList(EMPTY, SerialObject.class);
+    Assert.assertTrue(!optional.isPresent());
+  }
+  
+  @Data
+  private static class SerialObject implements Serializable {
+    
+    private static final long serialVersionUID = -1325200022332517446L;
+
+    @XmlElement
+    private String str;
+    
+    @XmlElement
+    private int num;
+    
+  }
+}
+


### PR DESCRIPTION
Since we are converting to and from Json a lot, I figured having a utility class to handle this would be easier instead of using the Jackson ObjectMapper and reimplementing the same code everywhere.