### PR TITLE
Adding RestClientUtil.rethrowFourOhFour

### DIFF
--- a/src/main/java/edu/psu/swe/commons/jaxrs/utilities/RestClientUtil.java
+++ b/src/main/java/edu/psu/swe/commons/jaxrs/utilities/RestClientUtil.java
@@ -74,7 +74,7 @@ public final class RestClientUtil {
     return false;
   }
   
-  public static void rethrowFourOhFour(WebTarget target, Response response) throws RestClientException {
+  public static void verifyFourOhFour(WebTarget target, Response response) throws RestClientException {
     if (response.getStatus() == Status.NOT_FOUND.getStatusCode()) {
       try {
         ErrorMessage em = response.readEntity(ErrorMessage.class);

--- a/src/main/java/edu/psu/swe/commons/jaxrs/utilities/RestClientUtil.java
+++ b/src/main/java/edu/psu/swe/commons/jaxrs/utilities/RestClientUtil.java
@@ -63,15 +63,12 @@ public final class RestClientUtil {
   }
   
   public static boolean checkForFourOhFour(WebTarget target, Response response) {
-    if (response.getStatus() == Status.NOT_FOUND.getStatusCode()) {
-      try {
-        response.readEntity(ErrorMessage.class);
-        return true;
-      } catch (ProcessingException pe) {
-        throw new BadUrlException(target.getUri().toASCIIString() + " could not be found");
-      }
+    try {
+      verifyFourOhFour(target, response);
+      return true;
+    } catch (RestClientException e) {
+      return false;
     }
-    return false;
   }
   
   public static void verifyFourOhFour(WebTarget target, Response response) throws RestClientException {

--- a/src/main/java/edu/psu/swe/commons/jaxrs/utilities/RestClientUtil.java
+++ b/src/main/java/edu/psu/swe/commons/jaxrs/utilities/RestClientUtil.java
@@ -25,6 +25,7 @@ import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.Response.Status.Family;
 
 import edu.psu.swe.commons.jaxrs.ErrorMessage;
@@ -36,8 +37,6 @@ import edu.psu.swe.commons.jaxrs.exceptions.RestServerException;
 import edu.psu.swe.commons.jaxrs.exceptions.ServiceAuthException;
 
 public final class RestClientUtil {
-  
-  private static final int NOT_FOUND = 404;
 
   private RestClientUtil() {
 
@@ -54,7 +53,7 @@ public final class RestClientUtil {
         throw new ConflictingDataException(response);
       } else if (status == 412) {
         throw new BackingStoreChangedException(response);
-      } else if (status == NOT_FOUND) {
+      } else if (status == Status.NOT_FOUND.getStatusCode()) {
         //If the record doesn't exist let the client handle gracefully
         return;
       } else {
@@ -64,7 +63,7 @@ public final class RestClientUtil {
   }
   
   public static boolean checkForFourOhFour(WebTarget target, Response response) {
-    if (response.getStatus() == NOT_FOUND) {
+    if (response.getStatus() == Status.NOT_FOUND.getStatusCode()) {
       try {
         response.readEntity(ErrorMessage.class);
         return true;
@@ -76,10 +75,10 @@ public final class RestClientUtil {
   }
   
   public static void rethrowFourOhFour(WebTarget target, Response response) throws RestClientException {
-    if (response.getStatus() == NOT_FOUND) {
+    if (response.getStatus() == Status.NOT_FOUND.getStatusCode()) {
       try {
         ErrorMessage em = response.readEntity(ErrorMessage.class);
-        throw new RestClientException(NOT_FOUND, em);
+        throw new RestClientException(Status.NOT_FOUND.getStatusCode(), em);
       } catch (ProcessingException pe) {
         throw new BadUrlException(target.getUri().toASCIIString() + " could not be found");
       }

--- a/src/main/java/edu/psu/swe/commons/jaxrs/utilities/RestClientUtil.java
+++ b/src/main/java/edu/psu/swe/commons/jaxrs/utilities/RestClientUtil.java
@@ -65,9 +65,9 @@ public final class RestClientUtil {
   public static boolean checkForFourOhFour(WebTarget target, Response response) {
     try {
       verifyFourOhFour(target, response);
-      return true;
-    } catch (RestClientException e) {
       return false;
+    } catch (RestClientException e) {
+      return true;
     }
   }
   

--- a/src/main/java/edu/psu/swe/commons/jaxrs/utilities/RestClientUtil.java
+++ b/src/main/java/edu/psu/swe/commons/jaxrs/utilities/RestClientUtil.java
@@ -75,7 +75,7 @@ public final class RestClientUtil {
     return false;
   }
   
-  public static void rethrowFourOfFour(WebTarget target, Response response) throws RestClientException {
+  public static void rethrowFourOhFour(WebTarget target, Response response) throws RestClientException {
     if (response.getStatus() == NOT_FOUND) {
       try {
         ErrorMessage em = response.readEntity(ErrorMessage.class);


### PR DESCRIPTION
The current implementation of 404 checking consume the ErrorMessage from the REST response and returns a true or false if it was a 404. For things that return an Optional this works well, but sometime we might want to re-throw the Exception so that we can pass along the underlying error message. I think that this is a good way of dealing with this issue. Does anyone have concerns or comments?