### PR TITLE
Updates jackson version for vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <javaee-api.version>7.0</javaee-api.version>
     <javax.mail.version>1.6.0</javax.mail.version>
-    <jackson.version>2.9.10</jackson.version>
+    <jackson.version>2.10.0</jackson.version>
     <resteasy.version>3.9.0.Final</resteasy.version>
     <commons-net.version>3.6</commons-net.version>
     <antlr-runtime.version>4.7.1</antlr-runtime.version>


### PR DESCRIPTION
Updates Jackson dependency version to patch:  
jackson-databind-2.9.10.jar: CVE-2019-16942, CVE-2019-16943